### PR TITLE
Allow assigning chores to "Personne"

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -133,7 +133,9 @@ export const TaskCard: React.FC<TaskCardProps> = ({
                         onClick={() => handleComplete(member.id)}
                         className="block w-full text-left px-3 py-2 text-sm hover:bg-gray-100"
                       >
-                        Par {member.name} (aide)
+                        {member.id === 'none'
+                          ? member.name
+                          : `Par ${member.name} (aide)`}
                       </button>
                     ))}
                 </div>

--- a/src/data/initialData.ts
+++ b/src/data/initialData.ts
@@ -1,6 +1,7 @@
 import { FamilyMember, ChoreTask } from '../types';
 
 export const familyMembers: FamilyMember[] = [
+  { id: 'none', name: 'Personne', isPrimary: false },
   { id: 'nathan', name: 'Nathan', isPrimary: true },
   { id: 'anna', name: 'Anna', isPrimary: true },
   { id: 'aaron', name: 'Aaron', isPrimary: true },

--- a/src/hooks/useChoreManager.ts
+++ b/src/hooks/useChoreManager.ts
@@ -79,11 +79,15 @@ export const useChoreManager = () => {
   const completeTask = (assignmentId: string, completedBy?: string) => {
     setAssignments(prev => prev.map(assignment => {
       if (assignment.id === assignmentId) {
-        const wasHelped = completedBy && completedBy !== assignment.assignedTo;
-        
-        if (wasHelped) {
+        const wasHelped =
+          completedBy &&
+          completedBy !== assignment.assignedTo &&
+          completedBy !== 'none';
+        const wasMissed = completedBy === 'none';
+
+        if (wasHelped || wasMissed) {
           // Update balance counters
-          updateBalanceCounters(assignment.assignedTo, completedBy);
+          updateBalanceCounters(assignment.assignedTo, wasHelped ? completedBy : undefined);
         }
 
         return {
@@ -111,9 +115,9 @@ export const useChoreManager = () => {
     }));
   };
 
-  const updateBalanceCounters = (originalAssignee: string, helper: string) => {
+  const updateBalanceCounters = (originalAssignee: string, helper?: string) => {
     setBalanceCounters(prev => prev.map(counter => {
-      if (counter.memberId === helper) {
+      if (helper && helper !== 'none' && counter.memberId === helper) {
         const newHelpCount = counter.helpCount + 1;
         return {
           ...counter,

--- a/supabase/migrations/20250904000000_add_personne_member.sql
+++ b/supabase/migrations/20250904000000_add_personne_member.sql
@@ -1,0 +1,10 @@
+-- Ajoute le membre spécial "Personne" et initialise son compteur d'équilibrage
+
+INSERT INTO family_members (id, name, is_primary)
+VALUES ('none', 'Personne', false)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO balance_counters (member_id, help_count, missed_count, net_balance)
+VALUES ('none', 0, 0, 0)
+ON CONFLICT (member_id) DO NOTHING;
+


### PR DESCRIPTION
## Summary
- Add special `Personne` member to initial data and Supabase migrations
- Permit selecting `Personne` when completing chores and adjust balance counter logic

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7f0fb0d848328bd20ed7af1afc836