### PR TITLE
feat: allow clearing task history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,8 @@ function App() {
     completeTask,
     reassignTask,
     getTodayAssignments,
-    getRecentHistory
+    getRecentHistory,
+    refreshData
   } = useSupabaseChores();
 
   // Generate today's assignments on load
@@ -28,7 +29,7 @@ function App() {
     if (familyMembers.length > 0 && choreTasks.length > 0) {
       generateTodayAssignments();
     }
-  }, [familyMembers, choreTasks]);
+  }, [familyMembers, choreTasks, generateTodayAssignments]);
 
   const todayAssignments = getTodayAssignments();
   const recentHistory = getRecentHistory();
@@ -111,6 +112,7 @@ function App() {
             history={recentHistory}
             tasks={choreTasks}
             familyMembers={familyMembers}
+            refreshData={refreshData}
           />
         );
 


### PR DESCRIPTION
## Summary
- add admin-only "Effacer l’historique" button to TaskHistory
- verify secret code from Supabase or env before deleting assignments
- wire App to refresh data after history purge

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7f0fc9da483288b18e133bfc638b1